### PR TITLE
Release 3.0.0

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -4,5 +4,5 @@ from .handshake import *
 from .headers import *
 from .identity import *
 
-version = "2.3.3"
-version_info = (2, 3, 3, 0)
+version = "2.3.4"
+version_info = (2, 3, 4, 0)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -3,3 +3,6 @@ from .events import *
 from .handshake import *
 from .headers import *
 from .identity import *
+
+version = "2.3.2"
+version_info = (2, 3, 2, 0)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -4,5 +4,5 @@ from .handshake import *
 from .headers import *
 from .identity import *
 
-version = "2.3.4"
-version_info = (2, 3, 4, 0)
+version = "3.0.0"
+version_info = (3, 0, 0, 0)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -4,5 +4,5 @@ from .handshake import *
 from .headers import *
 from .identity import *
 
-version = "2.3.2"
-version_info = (2, 3, 2, 0)
+version = "2.3.3"
+version_info = (2, 3, 3, 0)

--- a/cats/codecs.py
+++ b/cats/codecs.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, IO, List, Optional, Type, Union
 
 import ujson
 
-from cats.headers import Headers
+from cats.headers import T_Headers
 from cats.utils import tmp_file
 
 __all__ = [
@@ -59,7 +59,7 @@ class BaseCodec:
     type_name: str
 
     @classmethod
-    async def encode(cls, data: Any, headers) -> bytes:
+    async def encode(cls, data: Any, headers: T_Headers) -> bytes:
         """
         :raise TypeError: Encoder doesn't support this type
         :raise ValueError: Failed to encode
@@ -67,7 +67,7 @@ class BaseCodec:
         raise NotImplementedError
 
     @classmethod
-    async def decode(cls, data: Union[bytes, Path], headers) -> Any:
+    async def decode(cls, data: Union[bytes, Path], headers: T_Headers) -> Any:
         """
         :raise TypeError: Encoder doesn't support this type
         :raise ValueError: Failed to decode
@@ -80,14 +80,14 @@ class ByteCodec(BaseCodec):
     type_name = 'bytes'
 
     @classmethod
-    async def encode(cls, data: Byte, headers: Headers, offset: int) -> bytes:
+    async def encode(cls, data: Byte, headers: T_Headers, offset: int = 0) -> bytes:
         if data is not None and not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError(f'{cls.__name__} does not support {type(data).__name__}')
 
         return (bytes(data) if data else bytes())[offset:]
 
     @classmethod
-    async def decode(cls, data: bytes, headers) -> bytes:
+    async def decode(cls, data: bytes, headers: T_Headers) -> bytes:
         return bytes(data) if data else bytes()
 
 
@@ -97,7 +97,7 @@ class JsonCodec(BaseCodec):
     encoding = 'utf-8'
 
     @classmethod
-    async def encode(cls, data: Json, headers: Headers, offset: int) -> bytes:
+    async def encode(cls, data: Json, headers: T_Headers, offset: int = 0) -> bytes:
         if not isinstance(data, (str, int, float, dict, list, bool, type(None))):
             raise TypeError(f'{cls.__name__} does not support {type(data).__name__}')
 
@@ -162,7 +162,7 @@ class FileCodec(BaseCodec):
             return data
 
     @classmethod
-    async def encode(cls, data: FILE_TYPES, headers: Headers, offset: int) -> Path:
+    async def encode(cls, data: FILE_TYPES, headers: T_Headers, offset: int = 0) -> Path:
         tmp = tmp_file()
         try:
             buff = tuple(cls.normalize_input(data).items())
@@ -249,7 +249,7 @@ class Codec:
     }
 
     @classmethod
-    async def encode(cls, buff: Union[Byte, Json, FILE_TYPES], headers: Headers, offset: int = 0) -> (bytes, int):
+    async def encode(cls, buff: Union[Byte, Json, FILE_TYPES], headers: T_Headers, offset: int = 0) -> (bytes, int):
         """
         Takes any supported data type and returns tuple (encoded: bytes, type_id: int)
         """
@@ -263,7 +263,7 @@ class Codec:
         raise TypeError(f'Failed to encode data: Type {type(buff).__name__} not supported')
 
     @classmethod
-    async def decode(cls, buff: Union[Byte, Path], data_type: int, headers: Headers) -> Union[Byte, Json, Files]:
+    async def decode(cls, buff: Union[Byte, Path], data_type: int, headers: T_Headers) -> Union[Byte, Json, Files]:
         """
         Takes byte buffer, type_id and try to decode it to internal data types
         """

--- a/cats/headers.py
+++ b/cats/headers.py
@@ -1,11 +1,16 @@
+from typing import Any, Dict, Union
+
 import ujson
 
 from cats.errors import ProtocolError
 from cats.typing import Bytes
 
 __all__ = [
+    'T_Headers',
     'Headers',
 ]
+
+T_Headers = Union[Dict[str, Any], 'Headers']
 
 
 class Headers(dict):

--- a/cats/identity.py
+++ b/cats/identity.py
@@ -1,13 +1,17 @@
+from typing import List, Type
+
 __all__ = [
+    'IdentityMeta',
     'Identity',
 ]
 
 
 class IdentityMeta(type):
-    __identity_registry__ = []
+    __identity_registry__: List[Type['Identity']] = []
 
     def __new__(mcs, name, bases, attrs):
         cls = super().__new__(mcs, name, bases, attrs)
+        # noinspection PyTypeChecker
         IdentityMeta.__identity_registry__.append(cls)
         return cls
 

--- a/cats/identity.pyi
+++ b/cats/identity.pyi
@@ -1,9 +1,16 @@
-from typing import List
+from typing import List, Type
 
 
-class Identity:
-    identity_list: List[Identity]
+class IdentityMeta(type):
+    __identity_registry__: List[Type['Identity']] = []
 
+    def __new__(mcs, name, bases, attrs): ...
+
+    @property
+    def identity_list(cls) -> List[Type['Identity']]: ...
+
+
+class Identity(metaclass=IdentityMeta):
     @property
     def id(self) -> int:
         raise NotImplementedError

--- a/cats/server/app.py
+++ b/cats/server/app.py
@@ -13,6 +13,7 @@ __all__ = [
 
 class Application:
     __slots__ = ('_handlers', '_middleware', '_events', '_channels', 'idle_timeout', 'input_timeout')
+    INPUT_LIMIT: int = 3
 
     def __init__(self, apis: List[Api], middleware: List[Middleware] = None,
                  idle_timeout: Union[int, float] = None, input_timeout: Union[int, float] = None):

--- a/cats/server/conn.py
+++ b/cats/server/conn.py
@@ -259,7 +259,7 @@ class Connection:
             if self._idle_timer is not None:
                 self._idle_timer.cancel()
 
-            self._idle_timer = self.loop.call_later(self.app.idle_timeout, partial(self.close, TimeoutError))
+            self._idle_timer = self.loop.call_later(self.app.idle_timeout, partial(self.close, TimeoutError()))
 
     def _get_free_message_id(self) -> int:
         while True:

--- a/cats/server/conn.pyi
+++ b/cats/server/conn.pyi
@@ -15,7 +15,7 @@ class Connection:
 
     __slots__ = (
         '_closed', 'stream', 'host', 'port', 'api_version', '_app', '_scope', 'download_speed',
-        '_identity', 'loop', 'input_queue', '_idle_timer', '_message_pool', 'is_sending',
+        '_identity', '_credentials', 'loop', 'input_queue', '_idle_timer', '_message_pool', 'is_sending',
     )
 
     def __init__(self, stream: IOStream, address: Tuple[str, int], api_version: int, app: Application):
@@ -27,6 +27,7 @@ class Connection:
         self._app: Application
         self._scope: Scope
         self._identity: Optional[Identity] = None
+        self._credentials: Any = None
         self.loop: BaseEventLoop
         self.input_queue: Dict[int, Future]
         self._idle_timer: Optional[Future]
@@ -65,11 +66,14 @@ class Connection:
     def identity(self) -> Optional[Identity]: ...
 
     @property
+    def credentials(self) -> Optional[Any]: ...
+
+    @property
     def identity_scope_user(self): ...
 
     def signed_in(self) -> bool: ...
 
-    def sign_in(self, identity: Identity): ...
+    def sign_in(self, identity: Identity, credentials: Any = None): ...
 
     def sign_out(self): ...
 

--- a/cats/server/middleware.py
+++ b/cats/server/middleware.py
@@ -18,8 +18,13 @@ Middleware = Callable[[HandlerFunc, Request], Optional[Any]]
 async def default_error_handler(handler: HandlerFunc, request: Request):
     try:
         return await handler(request)
-    except (KeyboardInterrupt, StreamClosedError, CancelledError):
+    except (KeyboardInterrupt, StreamClosedError):
         raise
+    except CancelledError:
+        return Response(data={
+            'error': 'CancelledError',
+            'message': 'Request was cancelled',
+        }, status=500)
     except Exception as err:
         return Response(data={
             'error': err.__class__.__name__,

--- a/cats/server/request.py
+++ b/cats/server/request.py
@@ -3,7 +3,7 @@ from abc import ABCMeta
 from asyncio import Future
 from datetime import datetime, timezone
 from struct import Struct
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 from cats.codecs import Codec
 from cats.compression import Compressor
@@ -50,7 +50,7 @@ class BaseRequest(dict):
     def get_class_by_type_id(cls, message_type: int) -> Optional[Type['BaseRequest']]:
         return cls.__registry__.get(message_type)
 
-    async def input(self, data: Any = None, headers: Headers = None,
+    async def input(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
                     data_type: int = None, compression: int = None) -> 'InputRequest':
         fut = Future()
         if self.message_id in self.conn.input_queue:
@@ -243,7 +243,7 @@ class InputRequest(BasicRequest, type_id=0x02, struct=Struct('>HBBI')):
         await request.recv_data()
         return request
 
-    async def answer(self, data: Any = None, headers: Headers = None,
+    async def answer(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
                      compression: int = None, data_type: int = None) -> None:
         response = InputResponse(data=data, headers=headers, compression=compression, data_type=data_type)
         response.message_id = self.message_id

--- a/cats/server/request.pyi
+++ b/cats/server/request.pyi
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from datetime import datetime, timezone
 from struct import Struct
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 from cats.headers import Headers
 from cats.server.conn import Connection
@@ -33,7 +33,7 @@ class BaseRequest(dict):
     @classmethod
     def get_class_by_type_id(cls, message_type: int) -> Optional[Type['BaseRequest']]: ...
 
-    async def input(self, data: Any = None, headers: Headers = None,
+    async def input(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
                     data_type: int = None, compression: int = None) -> 'InputRequest': ...
 
     @classmethod
@@ -88,7 +88,7 @@ class InputRequest(BasicRequest, type_id=0x02, struct=Struct('>HBBI')):
     @classmethod
     async def recv_from_conn(cls, conn: Connection) -> 'InputRequest': ...
 
-    async def answer(self, data: Any = None, headers: Headers = None,
+    async def answer(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
                      compression: int = None, data_type: int = None) -> None: ...
 
 

--- a/cats/server/request.pyi
+++ b/cats/server/request.pyi
@@ -1,17 +1,36 @@
 from abc import ABCMeta
+from asyncio import Future, Task
 from datetime import datetime, timezone
 from struct import Struct
 from typing import Any, Dict, Optional, Type, Union
 
-from cats.headers import Headers
+from cats.headers import Headers, T_Headers
 from cats.server.conn import Connection
+from cats.typing import PingData
 
 __all__ = [
+    'Input',
     'BaseRequest',
     'Request',
     'StreamRequest',
     'InputRequest',
+    'DownloadSpeed',
+    'CancelInput',
+    'Ping',
 ]
+
+
+class Input:
+    def __init__(self, future: Future, timeout: Optional[int], conn: Connection, message_id: int, bypass_count: bool):
+        self.future: Future = future
+        self.timer: Optional[Task] = None
+        self.conn: Connection = conn
+        self.message_id: int = message_id
+        self.bypass_count: bool = bypass_count
+        if timeout:
+            self.timer = self.conn.loop.call_later(timeout, self.cancel)
+
+    def cancel(self): ...
 
 
 class BaseRequest(dict):
@@ -20,12 +39,14 @@ class BaseRequest(dict):
     type_id: int
     struct: Struct
     HEADER_SEPARATOR = b'\x00\x00'
+    status: Union[property, int]
 
-    def __init__(self, conn: Connection, message_id: int):
+    def __init__(self, conn: Connection, message_id: int, *, headers: T_Headers = None, status: int = 200):
         super().__init__()
         self.conn: Connection = conn
         self.message_id = message_id
-        self.headers = Headers()
+        self.headers = Headers(headers or {})
+        self.status = self.headers.get('Status', status or 200)
         self.data = None
 
     def __init_subclass__(cls, /, type_id: int = 0, struct: Struct = None): ...
@@ -33,8 +54,10 @@ class BaseRequest(dict):
     @classmethod
     def get_class_by_type_id(cls, message_type: int) -> Optional[Type['BaseRequest']]: ...
 
-    async def input(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
-                    data_type: int = None, compression: int = None) -> 'InputRequest': ...
+    async def input(self, data: Any = None, data_type: int = None, compression: int = None, *,
+                    headers: T_Headers = None, status: int = None,
+                    bypass_limit: bool = False, bypass_count: bool = False,
+                    timeout: Union[int, float] = None) -> 'InputRequest': ...
 
     @classmethod
     async def recv_from_conn(cls, conn: Connection) -> 'BaseRequest':
@@ -44,11 +67,12 @@ class BaseRequest(dict):
 class BasicRequest(BaseRequest, metaclass=ABCMeta):
     __slots__ = ('data_type', 'data_len', 'compression')
 
-    def __init__(self, conn: Connection, message_id: int, data_type: int, compression: int = 0, data_len: int = 0):
+    def __init__(self, conn: Connection, message_id: int, data_type: int, compression: int = 0, data_len: int = 0, *,
+                 headers: T_Headers = None, status: int = None):
         self.data_len = data_len
         self.data_type = data_type
         self.compression = compression
-        super().__init__(conn, message_id)
+        super().__init__(conn, message_id, headers=headers, status=status)
 
     async def recv_data(self) -> None: ...
 
@@ -57,22 +81,22 @@ class Request(BasicRequest, type_id=0x00, struct=Struct('>HHQBBI')):
     __slots__ = ('handler_id', 'send_time', 'data_type', 'data_len', 'compression')
 
     def __init__(self, conn: Connection, message_id: int, handler_id: int, data_type: int,
-                 send_time: datetime = None, compression: int = 0, data_len: int = 0):
+                 send_time: datetime = None, compression: int = 0, data_len: int = 0, *,
+                 headers: T_Headers = None, status: int = None):
         self.handler_id = handler_id
         self.send_time = send_time or datetime.now(timezone.utc)
         super().__init__(conn=conn, message_id=message_id,
-                         compression=compression, data_type=data_type, data_len=data_len)
-
-    @property
-    def status(self) -> Optional[int]: ...
+                         compression=compression, data_type=data_type, data_len=data_len,
+                         headers=headers, status=status)
 
     @classmethod
     async def recv_from_conn(cls, conn) -> 'Request': ...
 
 
 class StreamRequest(Request, type_id=0x01, struct=Struct('>HHQBB')):
-    def __init__(self, conn, message_id: int, handler_id: int, data_type: int, send_time: datetime = None):
-        super().__init__(conn, message_id, handler_id, data_type, send_time)
+    def __init__(self, conn, message_id: int, handler_id: int, data_type: int, send_time: datetime = None, *,
+                 headers: T_Headers = None, status: int = None):
+        super().__init__(conn, message_id, handler_id, data_type, send_time, headers=headers, status=status)
 
     @classmethod
     async def recv_from_conn(cls, conn: Connection) -> 'StreamRequest': ...
@@ -88,10 +112,24 @@ class InputRequest(BasicRequest, type_id=0x02, struct=Struct('>HBBI')):
     @classmethod
     async def recv_from_conn(cls, conn: Connection) -> 'InputRequest': ...
 
-    async def answer(self, data: Any = None, headers: Union[Dict[str, Any], Headers] = None,
-                     compression: int = None, data_type: int = None) -> None: ...
+    async def answer(self, data: Any = None, compression: int = None, data_type: int = None, *,
+                     headers: T_Headers = None, status: int = None) -> None: ...
+
+    async def cancel(self) -> None: ...
 
 
-class _DownloadSpeed(BaseRequest, type_id=0x05, struct=Struct('>I')):
+class CancelInput(BaseRequest, type_id=0x06, struct=Struct('>H')):
     @classmethod
-    async def recv_from_conn(cls, conn) -> '_DownloadSpeed': ...
+    async def recv_from_conn(cls, conn: Connection): ...
+
+
+class DownloadSpeed(BaseRequest, type_id=0x05, struct=Struct('>I')):
+    @classmethod
+    async def recv_from_conn(cls, conn: Connection) -> 'DownloadSpeed': ...
+
+
+class Ping(BaseRequest, type_id=0xFF, struct=Struct('>Q')):
+    data: PingData
+
+    @classmethod
+    async def recv_from_conn(cls, conn) -> 'Ping': ...

--- a/cats/typing.py
+++ b/cats/typing.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from datetime import datetime
 from typing import AsyncGenerator, Generator, Union
 
 __all__ = [
@@ -5,8 +7,16 @@ __all__ = [
     'BytesGen',
     'BytesAsyncGen',
     'BytesAnyGen',
+    'PingData',
 ]
+
 Bytes = Union[bytes, bytearray, memoryview]
 BytesGen = Generator[Bytes, None, None]
 BytesAsyncGen = AsyncGenerator[Bytes, None]
 BytesAnyGen = Union[BytesGen, BytesAsyncGen]
+
+
+@dataclass
+class PingData:
+    send_time: datetime
+    recv_time: datetime

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,17 +19,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "21.2.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bleach"
@@ -81,11 +81,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "4.4.2"
+version = "5.5"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 name = "cryptography"
@@ -108,7 +111,7 @@ test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pret
 
 [[package]]
 name = "django"
-version = "3.2"
+version = "3.2.2"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "dev"
 optional = false
@@ -136,7 +139,7 @@ django = ">=2.2"
 
 [[package]]
 name = "docutils"
-version = "0.17"
+version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
@@ -152,7 +155,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.10.0"
+version = "4.0.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -253,7 +256,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.8.1"
+version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
@@ -269,7 +272,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.3"
+version = "6.2.4"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -290,28 +293,28 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.14.0"
+version = "0.15.1"
 description = "Pytest support for asyncio."
 category = "dev"
 optional = false
-python-versions = ">= 3.5"
+python-versions = ">= 3.6"
 
 [package.dependencies]
 pytest = ">=5.4.0"
 
 [package.extras]
-testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.10.1"
+version = "2.11.1"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-coverage = ">=4.4"
+coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
@@ -393,7 +396,7 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rfc3986"
-version = "1.4.0"
+version = "1.5.0"
 description = "Validating URI References per RFC 3986"
 category = "dev"
 optional = false
@@ -416,7 +419,7 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "sentry-sdk"
-version = "0.20.3"
+version = "1.1.0"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -444,7 +447,7 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "six"
-version = "1.15.0"
+version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "dev"
 optional = false
@@ -548,8 +551,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8"
-content-hash = "2ff773d569f8e2c9da34558533a061c971026586060e7636709594c3f57c5c28"
+python-versions = "~3.8"
+content-hash = "bbafeee7b1615b5a1813330b5f0089bba90570dc23d375d0ff42d8851b5b933b"
 
 [metadata.files]
 asgiref = [
@@ -561,8 +564,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    { file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1" },
+    { file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb" },
 ]
 bleach = [
     {file = "bleach-3.3.0-py2.py3-none-any.whl", hash = "sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125"},
@@ -620,46 +623,58 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-4.4.2-cp26-cp26m-macosx_10_10_x86_64.whl", hash = "sha256:d1ee76f560c3c3e8faada866a07a32485445e16ed2206ac8378bd90dadffb9f0"},
-    {file = "coverage-4.4.2-cp26-cp26m-manylinux1_i686.whl", hash = "sha256:007eeef7e23f9473622f7d94a3e029a45d55a92a1f083f0f3512f5ab9a669b05"},
-    {file = "coverage-4.4.2-cp26-cp26m-manylinux1_x86_64.whl", hash = "sha256:17307429935f96c986a1b1674f78079528833410750321d22b5fb35d1883828e"},
-    {file = "coverage-4.4.2-cp26-cp26mu-manylinux1_i686.whl", hash = "sha256:845fddf89dca1e94abe168760a38271abfc2e31863fbb4ada7f9a99337d7c3dc"},
-    {file = "coverage-4.4.2-cp26-cp26mu-manylinux1_x86_64.whl", hash = "sha256:3f4d0b3403d3e110d2588c275540649b1841725f5a11a7162620224155d00ba2"},
-    {file = "coverage-4.4.2-cp27-cp27m-macosx_10_12_intel.whl", hash = "sha256:4c4f368ffe1c2e7602359c2c50233269f3abe1c48ca6b288dcd0fb1d1c679733"},
-    {file = "coverage-4.4.2-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:f8c55dd0f56d3d618dfacf129e010cbe5d5f94b6951c1b2f13ab1a2f79c284da"},
-    {file = "coverage-4.4.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:cdd92dd9471e624cd1d8c1a2703d25f114b59b736b0f1f659a98414e535ffb3d"},
-    {file = "coverage-4.4.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2ad357d12971e77360034c1596011a03f50c0f9e1ecd12e081342b8d1aee2236"},
-    {file = "coverage-4.4.2-cp27-cp27m-win32.whl", hash = "sha256:700d7579995044dc724847560b78ac786f0ca292867447afda7727a6fbaa082e"},
-    {file = "coverage-4.4.2-cp27-cp27m-win_amd64.whl", hash = "sha256:66f393e10dd866be267deb3feca39babba08ae13763e0fc7a1063cbe1f8e49f6"},
-    {file = "coverage-4.4.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:e9a0e1caed2a52f15c96507ab78a48f346c05681a49c5b003172f8073da6aa6b"},
-    {file = "coverage-4.4.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:eea9135432428d3ca7ee9be86af27cb8e56243f73764a9b6c3e0bda1394916be"},
-    {file = "coverage-4.4.2-cp33-cp33m-macosx_10_10_x86_64.whl", hash = "sha256:5ff16548492e8a12e65ff3d55857ccd818584ed587a6c2898a9ebbe09a880674"},
-    {file = "coverage-4.4.2-cp33-cp33m-manylinux1_i686.whl", hash = "sha256:d00e29b78ff610d300b2c37049a41234d48ea4f2d2581759ebcf67caaf731c31"},
-    {file = "coverage-4.4.2-cp33-cp33m-manylinux1_x86_64.whl", hash = "sha256:87d942863fe74b1c3be83a045996addf1639218c2cb89c5da18c06c0fe3917ea"},
-    {file = "coverage-4.4.2-cp34-cp34m-macosx_10_10_x86_64.whl", hash = "sha256:358d635b1fc22a425444d52f26287ae5aea9e96e254ff3c59c407426f44574f4"},
-    {file = "coverage-4.4.2-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:81912cfe276e0069dca99e1e4e6be7b06b5fc8342641c6b472cb2fed7de7ae18"},
-    {file = "coverage-4.4.2-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:079248312838c4c8f3494934ab7382a42d42d5f365f0cf7516f938dbb3f53f3f"},
-    {file = "coverage-4.4.2-cp34-cp34m-win32.whl", hash = "sha256:b0059630ca5c6b297690a6bf57bf2fdac1395c24b7935fd73ee64190276b743b"},
-    {file = "coverage-4.4.2-cp34-cp34m-win_amd64.whl", hash = "sha256:493082f104b5ca920e97a485913de254cbe351900deed72d4264571c73464cd0"},
-    {file = "coverage-4.4.2-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:e3ba9b14607c23623cf38f90b23f5bed4a3be87cbfa96e2e9f4eabb975d1e98b"},
-    {file = "coverage-4.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:82cbd3317320aa63c65555aa4894bf33a13fb3a77f079059eb5935eea415938d"},
-    {file = "coverage-4.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9721f1b7275d3112dc7ccf63f0553c769f09b5c25a26ee45872c7f5c09edf6c1"},
-    {file = "coverage-4.4.2-cp35-cp35m-win32.whl", hash = "sha256:bd4800e32b4c8d99c3a2c943f1ac430cbf80658d884123d19639bcde90dad44a"},
-    {file = "coverage-4.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:f29841e865590af72c4b90d7b5b8e93fd560f5dea436c1d5ee8053788f9285de"},
-    {file = "coverage-4.4.2-cp36-cp36m-macosx_10_12_x86_64.whl", hash = "sha256:f3a5c6d054c531536a83521c00e5d4004f1e126e2e2556ce399bef4180fbe540"},
-    {file = "coverage-4.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:dd707a21332615108b736ef0b8513d3edaf12d2a7d5fc26cd04a169a8ae9b526"},
-    {file = "coverage-4.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2e1a5c6adebb93c3b175103c2f855eda957283c10cf937d791d81bef8872d6ca"},
-    {file = "coverage-4.4.2-cp36-cp36m-win32.whl", hash = "sha256:f87f522bde5540d8a4b11df80058281ac38c44b13ce29ced1e294963dd51a8f8"},
-    {file = "coverage-4.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a7cfaebd8f24c2b537fa6a271229b051cdac9c1734bb6f939ccfc7c055689baa"},
-    {file = "coverage-4.4.2.tar.gz", hash = "sha256:309d91bd7a35063ec7a0e4d75645488bfab3f0b66373e7722f23da7f5b0f34cc"},
-    {file = "coverage-4.4.2.win-amd64-py2.7.exe", hash = "sha256:b6cebae1502ce5b87d7c6f532fa90ab345cfbda62b95aeea4e431e164d498a3d"},
-    {file = "coverage-4.4.2.win-amd64-py3.4.exe", hash = "sha256:a4497faa4f1c0fc365ba05eaecfb6b5d24e3c8c72e95938f9524e29dadb15e76"},
-    {file = "coverage-4.4.2.win-amd64-py3.5.exe", hash = "sha256:2b4d7f03a8a6632598cbc5df15bbca9f778c43db7cf1a838f4fa2c8599a8691a"},
-    {file = "coverage-4.4.2.win-amd64-py3.6.exe", hash = "sha256:1afccd7e27cac1b9617be8c769f6d8a6d363699c9b86820f40c74cfb3328921c"},
-    {file = "coverage-4.4.2.win32-py2.7.exe", hash = "sha256:0388c12539372bb92d6dde68b4627f0300d948965bbb7fc104924d715fdc0965"},
-    {file = "coverage-4.4.2.win32-py3.4.exe", hash = "sha256:ab3508df9a92c1d3362343d235420d08e2662969b83134f8a97dc1451cbe5e84"},
-    {file = "coverage-4.4.2.win32-py3.5.exe", hash = "sha256:43a155eb76025c61fc20c3d03b89ca28efa6f5be572ab6110b2fb68eda96bfea"},
-    {file = "coverage-4.4.2.win32-py3.6.exe", hash = "sha256:f98b461cb59f117887aa634a66022c0bd394278245ed51189f63a036516e32de"},
+    { file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf" },
+    { file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b" },
+    { file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669" },
+    { file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90" },
+    { file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c" },
+    { file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a" },
+    { file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82" },
+    { file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905" },
+    { file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083" },
+    { file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5" },
+    { file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81" },
+    { file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6" },
+    { file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0" },
+    { file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae" },
+    { file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb" },
+    { file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160" },
+    { file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6" },
+    { file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701" },
+    { file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793" },
+    { file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e" },
+    { file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3" },
+    { file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066" },
+    { file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a" },
+    { file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465" },
+    { file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb" },
+    { file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821" },
+    { file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45" },
+    { file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184" },
+    { file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a" },
+    { file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53" },
+    { file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d" },
+    { file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638" },
+    { file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3" },
+    { file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a" },
+    { file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a" },
+    { file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6" },
+    { file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2" },
+    { file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759" },
+    { file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873" },
+    { file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a" },
+    { file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6" },
+    { file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502" },
+    { file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b" },
+    { file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529" },
+    { file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b" },
+    { file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff" },
+    { file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b" },
+    { file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6" },
+    { file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03" },
+    { file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079" },
+    { file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4" },
+    { file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c" },
 ]
 cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1"},
@@ -676,24 +691,24 @@ cryptography = [
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 django = [
-    {file = "Django-3.2-py3-none-any.whl", hash = "sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927"},
-    {file = "Django-3.2.tar.gz", hash = "sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d"},
+    { file = "Django-3.2.2-py3-none-any.whl", hash = "sha256:18dd3145ddbd04bf189ff79b9954d08fda5171ea7b57bf705789fea766a07d50" },
+    { file = "Django-3.2.2.tar.gz", hash = "sha256:0a1d195ad65c52bf275b8277b3d49680bd1137a5f55039a806f25f6b9752ce3d" },
 ]
 djangorestframework = [
     {file = "djangorestframework-3.12.4-py3-none-any.whl", hash = "sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf"},
     {file = "djangorestframework-3.12.4.tar.gz", hash = "sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2"},
 ]
 docutils = [
-    {file = "docutils-0.17-py2.py3-none-any.whl", hash = "sha256:a71042bb7207c03d5647f280427f14bfbd1a65c9eb84f4b341d85fafb6bb4bdf"},
-    {file = "docutils-0.17.tar.gz", hash = "sha256:e2ffeea817964356ba4470efba7c2f42b6b0de0b04e66378507e3e2504bbff4c"},
+    { file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61" },
+    { file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125" },
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.10.0-py3-none-any.whl", hash = "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"},
-    {file = "importlib_metadata-3.10.0.tar.gz", hash = "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a"},
+    { file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d" },
+    { file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581" },
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -728,24 +743,24 @@ pycparser = [
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pygments = [
-    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
-    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
+    { file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e" },
+    { file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f" },
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.3-py3-none-any.whl", hash = "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"},
-    {file = "pytest-6.2.3.tar.gz", hash = "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634"},
+    { file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890" },
+    { file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b" },
 ]
 pytest-asyncio = [
-    {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
-    {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
+    { file = "pytest-asyncio-0.15.1.tar.gz", hash = "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f" },
+    { file = "pytest_asyncio-0.15.1-py3-none-any.whl", hash = "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea" },
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
-    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+    { file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7" },
+    { file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da" },
 ]
 pytest-tornado = [
     {file = "pytest-tornado-0.8.1.tar.gz", hash = "sha256:b9fa1930c333b9dfe29bde90f9f42e6643278b5d0c95528a8302a7454fd3f1b1"},
@@ -772,20 +787,20 @@ requests-toolbelt = [
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
 ]
 rfc3986 = [
-    {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},
-    {file = "rfc3986-1.4.0.tar.gz", hash = "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d"},
+    { file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97" },
+    { file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835" },
 ]
 secretstorage = [
     {file = "SecretStorage-3.3.1-py3-none-any.whl", hash = "sha256:422d82c36172d88d6a0ed5afdec956514b189ddbfb72fefab0c8a1cee4eaf71f"},
     {file = "SecretStorage-3.3.1.tar.gz", hash = "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-0.20.3.tar.gz", hash = "sha256:4ae8d1ced6c67f1c8ea51d82a16721c166c489b76876c9f2c202b8a50334b237"},
-    {file = "sentry_sdk-0.20.3-py2.py3-none-any.whl", hash = "sha256:e75c8c58932bda8cd293ea8e4b242527129e1caaec91433d21b8b2f20fee030b"},
+    { file = "sentry-sdk-1.1.0.tar.gz", hash = "sha256:c1227d38dca315ba35182373f129c3e2722e8ed999e52584e6aca7d287870739" },
+    { file = "sentry_sdk-1.1.0-py2.py3-none-any.whl", hash = "sha256:c7d380a21281e15be3d9f67a3c4fbb4f800c481d88ff8d8931f39486dd7b4ada" },
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    { file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254" },
+    { file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926" },
 ]
 sqlparse = [
     {file = "sqlparse-0.4.1-py3-none-any.whl", hash = "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0"},

--- a/publish
+++ b/publish
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+bash test || exit $?
 rm -rf dist
 python3 setup.py sdist bdist_wheel
 python3 -m twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cats-python"
-version = "2.3.2"
+version = "2.3.3"
 description = "Cifrazia Action Transport System for Python"
 authors = ["Bogdan Parfenov <adam.brian.bright@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cats-python"
-version = "2.3.0"
+version = "2.3.1"
 description = "Cifrazia Action Transport System for Python"
 authors = ["Bogdan Parfenov <adam.brian.bright@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,24 @@
 [tool.poetry]
 name = "cats-python"
-version = "2.3.4"
+version = "3.0.0"
 description = "Cifrazia Action Transport System for Python"
 authors = ["Bogdan Parfenov <adam.brian.bright@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = "~3.8"
+sentry-sdk = "^1.1.0"
 tornado = "^6.1"
 ujson = "^4.0.2"
-sentry-sdk = "^0.20.3"
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.1"
-pytest-cov = "^2.10.1"
-djangorestframework = "^3.12.2"
-pytest-asyncio = "^0.14.0"
+Django = ">=2.2"
+djangorestframework = "^3.12.4"
+pytest = "^6.2.4"
+pytest-asyncio = "^0.15.1"
+pytest-cov = "^2.11.1"
 pytest-tornado = "^0.8.1"
-twine = "^3.3.0"
+twine = "^3.4.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cats-python"
-version = "2.3.1"
+version = "2.3.2"
 description = "Cifrazia Action Transport System for Python"
 authors = ["Bogdan Parfenov <adam.brian.bright@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cats-python"
-version = "2.3.3"
+version = "2.3.4"
 description = "Cifrazia Action Transport System for Python"
 authors = ["Bogdan Parfenov <adam.brian.bright@gmail.com>"]
 license = "MIT"

--- a/test
+++ b/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+poetry run python -m pytest --cov-config=.coveragerc --cov=cats tests || exit $?
+poetry run python -m coverage xml -i
+poetry run python -m coverage html -i
+poetry run python -m coverage report > coverage.txt
+echo 'DONE';

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,3 +164,15 @@ async def test_api_payload_offset_files(cats_conn: Connection):
         assert isinstance(val, FileInfo)
         assert val.size == 5
         assert val.path.read_bytes() == b'67890'
+
+
+@mark.asyncio
+async def test_cancel_input(cats_conn: Connection):
+    await cats_conn.send(0xFFA0, None)
+    response = await cats_conn.recv()
+    assert isinstance(response, InputRequest)
+    assert response.data == b'Are you ok?'
+    await response.cancel()
+    response = await cats_conn.recv()
+    assert isinstance(response, Request)
+    assert response.status == 500, response.data


### PR DESCRIPTION
# Release 3.0.0

**Additions**

+ Added `request.input()` timeout support
+ Added version in `__init__.py`
+ Added `CancelInput` support
  + Added Header type `06` (6) for cancelling pending inputs
  + Added `async InputRequest.cancel()` method
+ Added Ping support.
  + Connection now has `ping` method
  + Method `Connection.start()` now supports `ping=False` argument
  + Added Header type `FF` (255) for ping-pong mechanism
+ Connection`.sign_in` now requires `(identity: Identity, credentials: Any = None)`
+ Added `cats.headers.T_Header` typing alias for `Union[Dict[str, Any], Headers]`

**Changes**

- Remade `Connection.input_queue: Dict[int, Future]` to `Connection.input_deq: Dict[int, Input]`
- Remade `headers` and `status` argument position and type. They are now keyword-only and the very end.
- `Request.status` and `Response.status` are full properties to `self.headers['Status']`
- Middleware `default_error_handler` now catches `CancelledError` and returns it as `Response`
+ Method `request.input()` now supports `bypass_limit: bool`, `bypass_count: bool`, `timeout: int|float` arguments
+ Method `Handler.input()` now mirrors `request.input()` arguments

**Fixes**

+ Fixed `cats.identity.pyi` mismatch
+ Fixed `cats.identity.IdentityMeta` was not exported
+ Fixed Header type hinting in cats.request module
+ Fixed `invalid idle_timeout` error instance
+ Fixed Codecs arguments type-hinting for Headers
